### PR TITLE
CI/CD: updated target repositories, updated distros

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ deploy:
   # Deploy packages to PackageCloud
   - provider: packagecloud
     username: tarantool
-    repository: "1_6"
+    repository: "1_9"
     token: ${PACKAGECLOUD_TOKEN}
     dist: ${OS}/${DIST}
     package_glob: build/*.{rpm,deb}
@@ -59,7 +59,7 @@ deploy:
       condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
   - provider: packagecloud
     username: tarantool
-    repository: "1_7"
+    repository: "1_10"
     token: ${PACKAGECLOUD_TOKEN}
     dist: ${OS}/${DIST}
     package_glob: build/*.{rpm,deb}
@@ -69,7 +69,7 @@ deploy:
       condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
   - provider: packagecloud
     username: tarantool
-    repository: "1_8"
+    repository: "2x"
     token: ${PACKAGECLOUD_TOKEN}
     dist: ${OS}/${DIST}
     package_glob: build/*.{rpm,deb}

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,31 +11,16 @@ env:
     global:
       - PRODUCT=tarantool-gis
     matrix:
-#      - OS=el DIST=6
       - OS=el DIST=7
-      - OS=fedora DIST=24
-      - OS=fedora DIST=25
-#      - OS=ubuntu DIST=precise
+      - OS=fedora DIST=26
+      - OS=fedora DIST=27
       - OS=ubuntu DIST=trusty
       - OS=ubuntu DIST=xenial
-      - OS=ubuntu DIST=yakkety
-#      - OS=debian DIST=wheezy
+      - OS=ubuntu DIST=artful
+      - OS=ubuntu DIST=bionic
+      - OS=ubuntu DIST=cosmic
       - OS=debian DIST=jessie
       - OS=debian DIST=stretch
-
-#matrix:
-#    allow_failures:
-#      - env: OS=el DIST=6
-#      - env: OS=el DIST=7
-#      - env: OS=fedora DIST=24
-#      - env: OS=fedora DIST=25
-#      - env: OS=ubuntu DIST=precise
-#      - env: OS=ubuntu DIST=trusty
-#      - env: OS=ubuntu DIST=xenial
-#      - env: OS=ubuntu DIST=yakkety
-#      - env: OS=debian DIST=wheezy
-#      - env: OS=debian DIST=jessie
-#      - env: OS=debian DIST=stretch
 
 script:
   - git describe --long

--- a/debian/prebuild.sh
+++ b/debian/prebuild.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Configure tzdata in non-interactive way to avoid stuck on waiting user input
+# during dependencies installation.
+release=$(lsb_release -c -s)
+if [ "${release}" = "bionic" ] || [ "${release}" = "cosmic" ]; then
+    echo "Europe/Moscow" | sudo tee /etc/timezone
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata
+fi


### PR DESCRIPTION
Aside commits set PACKAGECLOUD_USER=tarantool and PACKAGECLOUD_REPO=1_10 in Travis-CI variables to provide tarantool packages for all supported distros.