### PR TITLE
travis-ci: update distributives and repositories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,17 @@ env:
       - PRODUCT=tarantool-gis
     matrix:
       - OS=el DIST=7
-      - OS=fedora DIST=26
-      - OS=fedora DIST=27
+      - OS=fedora DIST=28
+      - OS=fedora DIST=29
+      - OS=fedora DIST=30
       - OS=ubuntu DIST=trusty
       - OS=ubuntu DIST=xenial
-      - OS=ubuntu DIST=artful
       - OS=ubuntu DIST=bionic
       - OS=ubuntu DIST=cosmic
+      - OS=ubuntu DIST=disco
       - OS=debian DIST=jessie
       - OS=debian DIST=stretch
+      - OS=debian DIST=buster
 
 script:
   - git describe --long
@@ -55,6 +57,16 @@ deploy:
   - provider: packagecloud
     username: tarantool
     repository: "2x"
+    token: ${PACKAGECLOUD_TOKEN}
+    dist: ${OS}/${DIST}
+    package_glob: build/*.{rpm,deb}
+    skip_cleanup: true
+    on:
+      branch: master
+      condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
+  - provider: packagecloud
+    username: tarantool
+    repository: "2_2"
     token: ${PACKAGECLOUD_TOKEN}
     dist: ${OS}/${DIST}
     package_glob: build/*.{rpm,deb}

--- a/debian/prebuild.sh
+++ b/debian/prebuild.sh
@@ -3,7 +3,8 @@
 # Configure tzdata in non-interactive way to avoid stuck on waiting user input
 # during dependencies installation.
 release=$(lsb_release -c -s)
-if [ "${release}" = "bionic" ] || [ "${release}" = "cosmic" ]; then
+if [ "${release}" = "bionic" ] || [ "${release}" = "cosmic" ] || \
+        [ "${release}" = "disco" ]; then
     # Update packages list to overcome 404 Not found error at
     # downloading tzdata package.
     sudo apt-get update > /dev/null


### PR DESCRIPTION
Removed EOL distros, added new ones.

Added 2_2 repository to deploy to.