### PR TITLE
rockspec: use git+https:// for git repository URL

### DIFF
--- a/rockspecs/gis-1.0.0-1.rockspec
+++ b/rockspecs/gis-1.0.0-1.rockspec
@@ -2,7 +2,7 @@ package = 'gis'
 version = '1.0.0-1'
 
 source  = {
-    url = 'git://github.com/tarantool/gis.git';
+    url = 'git+https://github.com/tarantool/gis.git';
     tag = '1.0.0';
 }
 

--- a/rockspecs/gis-scm-1.rockspec
+++ b/rockspecs/gis-scm-1.rockspec
@@ -2,7 +2,7 @@ package = 'gis'
 version = 'scm-1'
 
 source  = {
-    url    = 'git://github.com/tarantool/gis.git';
+    url    = 'git+https://github.com/tarantool/gis.git';
     branch = 'master';
 }
 


### PR DESCRIPTION
GitHub is going to disable unencrypted Git protocol, so `git://` URLs
will stop working soon (see [1]).

[1]: https://github.blog/2021-09-01-improving-git-protocol-security-github/

Part of https://github.com/tarantool/tarantool/issues/6587